### PR TITLE
Create psl formatting library

### DIFF
--- a/psl/format.dox
+++ b/psl/format.dox
@@ -1,0 +1,115 @@
+/**
+ * @page psl_fmt PSL Formatting Library
+ * A type-safe, user-extensible string formatting library inspired by {fmt}.
+ *
+ * @section psl_fmt_str Format Strings
+ *
+ * Every format string can contain _substitutions_ and _escape sequences_.
+ *
+ * A _substitution_ is delimited by curly braces (`{` and `}`) and indicates
+ * that a formatting argument should be inserted at that location (see @ref
+ * psl_fmt_str_subst for details).
+ *
+ * An _escape sequence_ is one of `{{` or `}}`, and causes the corresponding
+ * brace character to be output.
+ *
+ * @note The format string is invalid if it contains any unescaped braces that
+ * do not denote a substitution. In this case, the output of the formatting
+ * functions is unspecified.
+ *
+ * @subsection psl_fmt_str_subst Substitutions
+ * A substitution indicates that a formatting argument should be output. The
+ * most basic substitution is simply `{}`, which indicates that the next
+ * formatting argument should be used. For example, the string `"hello {}"` will
+ * output `hello` followed by the first formatting argument.
+ *
+ * Optionally, a substitution may contain a colon followed by a _specification_,
+ * a string to be passed to the @ref psl_fmt_formatter "formatter". The
+ * exact meaning of the specification depends the formatter used. For example,
+ * the string `"test {:abcd}"` will output `test` followed by the first
+ * formatting argument, formatted with the specification `abcd` (the
+ * interpretation of which depends on the formatter).
+ *
+ * @note Escaped braces are not supported inside of substitutions - the first
+ * `}` encountered terminates the substitution.
+ *
+ * @section psl_fmt_output_sink Output Sinks
+ *
+ * Any callable object accepting a single argument of type psl::string_view is
+ * known as an _output sink_. Output sinks are used by the formatting
+ * functions to report the formatted output back to the caller in (possibly
+ * several) psl::string_view pieces.
+ *
+ * @note The exact decomposition of the formatted string into psl::string_view
+ * pieces is unspecified and is subject to change. Output sinks should not
+ * depend on a particular decomposition.
+ *
+ * @subsection psl_fmt_output_sink_ex Example
+ *
+ * Given the function
+ *
+ * @code{.cpp}
+ * void write_to_log(psl::string_view str) {
+ *   // ...
+ * }
+ * @endcode
+ *
+ * which writes to the log, the call
+ * @code{.cpp}
+ * psl::format(write_to_log, "hi {}", "there");
+ * @endcode
+ * will cause the string `"hi there"` to be written to the log, possibly in
+ * several pieces (i.e. there may be several calls to `write_to_log`).
+ *
+ * @section psl_fmt_formatter Formatters
+ *
+ * Formatters are the extensibility mechanism by which support for additional
+ * argument types can be added to the library. The class template
+ * psl::formatter should be specialized for any type wishing to support
+ * formatted output, and must contain a static member function with the
+ * following signature:
+ *
+ * @code{.cpp}
+ * template <typename O>
+ * static void format(O& output_sink, const T& val, psl::string_view spec);
+ * @endcode
+ *
+ * Where `output_sink` is the @ref psl_fmt_output_sink "output sink"
+ * being used, `val` is the value to be formatted, and `spec` is the
+ * specification extracted from the format string.
+ *
+ * psl::formatter has a second template argument defaulting to `void` which can
+ * be used for SFINAE.
+ *
+ * @subsection psl_fmt_formatter_builtin Built-in Formatters
+ * The library supports formatting for several types out of the box:
+ * - **String types** (those which convert implicitly to psl::string_view)
+ * - **Integer types**
+ * - **cv-void pointers** (but not other types of pointers)
+ * - `nullptr_t`
+ *
+ * @subsection psl_fmt_formatter_ex Custom Formatter Example
+ *
+ * The following defines a class `point` and a custom formatter for it.
+ *
+ * @code{.cpp}
+ * struct point {
+ *   int x, y;
+ * };
+ *
+ * template<>
+ * struct psl::formatter<point> {
+ *   template <typename O>
+ *   void format(O& output_sink, const point& pt, psl::string_view) {
+ *     psl::format(output_sink, "({}, {})", pt.x, pt.y);
+ *   }
+ * }
+ * @endcode
+ *
+ * `point` can then be used as a format argument:
+ *
+ * @code{.cpp}
+ * point pt = {1, 2};
+ * psl::format(..., "pt = {}", pt); // Outputs 'pt = (1, 2)'
+ * @endcode
+ */

--- a/psl/format.dox
+++ b/psl/format.dox
@@ -84,6 +84,8 @@
  * @subsection psl_fmt_formatter_builtin Built-in Formatters
  * The library supports formatting for several types out of the box:
  * - **String types** (those which convert implicitly to psl::string_view)
+ * - `char` - formats ASCII value. Note that `signed char` and `unsigned char`
+ *    are formatted as integers.
  * - **Integer types** - the following specifications are supported:
  *   - `x` - format as hexadecimal
  *   - `b` - format as binary

--- a/psl/format.dox
+++ b/psl/format.dox
@@ -84,7 +84,9 @@
  * @subsection psl_fmt_formatter_builtin Built-in Formatters
  * The library supports formatting for several types out of the box:
  * - **String types** (those which convert implicitly to psl::string_view)
- * - **Integer types**
+ * - **Integer types** - the following specifications are supported:
+ *   - `x` - format as hexadecimal
+ *   - `b` - format as binary
  * - **cv-void pointers** (but not other types of pointers)
  * - `nullptr_t`
  *

--- a/psl/format.dox
+++ b/psl/format.dox
@@ -106,7 +106,7 @@
  * template<>
  * struct psl::formatter<point> {
  *   template <typename O>
- *   void format(O& output_sink, const point& pt, psl::string_view) {
+ *   static void format(O& output_sink, const point& pt, psl::string_view) {
  *     psl::format(output_sink, "({}, {})", pt.x, pt.y);
  *   }
  * }
@@ -116,6 +116,6 @@
  *
  * @code{.cpp}
  * point pt = {1, 2};
- * psl::format(..., "pt = {}", pt); // Outputs 'pt = (1, 2)'
+ * psl::format(write_to_log, "pt = {}", pt); // Outputs 'pt = (1, 2)'
  * @endcode
  */

--- a/psl/format.dox
+++ b/psl/format.dox
@@ -89,6 +89,8 @@
  * - **Integer types** - the following specifications are supported:
  *   - `x` - format as hexadecimal
  *   - `b` - format as binary
+ * - **Booleans** - formatted as `true`/`false`. To print `1`/`0` instead, cast
+ * to an integer first (e.g. with unary `+`).
  * - **cv-void pointers** (but not other types of pointers)
  * - `nullptr_t`
  *

--- a/psl/include/psl/algorithm.h
+++ b/psl/include/psl/algorithm.h
@@ -27,6 +27,28 @@ constexpr InIt find(InIt first, InIt last, const T& val) {
   return last;
 }
 
+/**
+ * Search forward for an element satisfying the given predicate in `[first,
+ * last)`.
+ * @param first Input iterator indicating start of range.
+ * @param last Input iterator past end of range.
+ * @param pred Predicate to use. The expression `pred(v)` must be convertible to
+ * `bool`, where `v` is a value of the iterator's value type.
+ * @return An iterator pointing to the first element in the range that satisfies
+ * `pred`, or `last` if none is found.
+ */
+template <typename InIt, typename P>
+constexpr InIt find_if(InIt first, InIt last, P pred) {
+  for (; first != last; ++first) {
+    if (pred(*first)) {
+      return first;
+    }
+  }
+
+  return last;
+}
+
+
 } // namespace psl
 
 /** @} */

--- a/psl/include/psl/algorithm.h
+++ b/psl/include/psl/algorithm.h
@@ -1,0 +1,11 @@
+/**
+ * @addtogroup psl
+ * @{
+ * @file algorithm.h General-purpose algorithms, inspired by &lt;algorithm&gt;.
+ */
+
+#pragma once
+
+namespace psl {}
+
+/** @} */

--- a/psl/include/psl/algorithm.h
+++ b/psl/include/psl/algorithm.h
@@ -6,6 +6,27 @@
 
 #pragma once
 
-namespace psl {}
+namespace psl {
+
+/**
+ * Search forward for `val` in `[first, last)`.
+ * @param first Input iterator indicating start of range.
+ * @param last Input iterator past end of range.
+ * @param val Value to search for.
+ * @return An iterator pointing to the first element in the range that is equal
+ * to `val`, or `last` if none is found.
+ */
+template <typename InIt, typename T>
+constexpr InIt find(InIt first, InIt last, const T& val) {
+  for (; first != last; ++first) {
+    if (*first == val) {
+      return first;
+    }
+  }
+
+  return last;
+}
+
+} // namespace psl
 
 /** @} */

--- a/psl/include/psl/charconv.h
+++ b/psl/include/psl/charconv.h
@@ -6,45 +6,82 @@
 
 #pragma once
 
+#include <limits.h>
+#include <psl/iterator.h>
 #include <psl/type_traits.h>
+#include <string.h>
 
 namespace psl {
+namespace impl {
 
 /**
- * Represents a status code returned by the character conversion functions.
+ * Lookup table used to convert digits to their character representation.
  */
-enum class charconv_status {
-  ok,
-  overflow,
-  invalid_arg,
-};
+constexpr char to_chars_digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+} // namespace impl
 
 /**
- * Result returned by to_chars.
- */
-struct to_chars_result {
-  char* ptr;              ///< Indicates the end of the formatted number.
-  charconv_status status; ///< Status code.
-};
-
-
-/**
- * Convert an integer value into a character string and store it in `[begin,
- * end)`.
- * @param begin Pointer to the start of the result buffer.
- * @param end Pointer past the end of the result buffer.
+ * Convert an integer value into a character string and store it in `[first,
+ * last)`, which must be a valid range.
+ * @param first Pointer to the start of the result buffer.
+ * @param last Pointer past the end of the result buffer.
  * @param value Value to convert.
  * @param base Numerical base to use. Must be between 2 and 36.
- * @return On success, a result with @ref psl::to_chars_result::status "status"
- * set to `ok` and @ref psl::to_chars_result::ptr "ptr"
- * set past the end of the formatted number. On error, a result with @ref
- * psl::to_chars_result::status "status" set to the appropriate error code and
- * @ref psl::to_chars_result::ptr "ptr" set to `end`.
- * @note This function only participates in overload resolution if `I` is an
- * integer type.
+ * @return On success, a pointer past the end of the converted integer. On error
+ * (if the buffer is too small), returns `nullptr`.
+ * @note This function does not null terminate the output buffer.
  */
 template <typename I, typename = enable_if_t<is_integral_v<I>>>
-to_chars_result to_chars(char* begin, char* end, I value, int base = 10) {}
+char* to_chars(char* first, char* last, I value, int base = 10) {
+  auto uvalue = static_cast<psl::make_unsigned_t<I>>(value);
+
+  if constexpr (is_signed_v<I>) {
+    if (value < 0) {
+      // No need to check here since [first, last) is required to be a valid
+      // range.
+      *first++ = '-';
+      uvalue = -value;
+    }
+  }
+
+  // Conservative size estimate, sufficient even for smallest base.
+  char buf[sizeof(I) * CHAR_BIT];
+  char* rnext = psl::end(buf);
+
+  switch (base) {
+    // Improved codegen for common cases
+  case 10:
+    do {
+      *--rnext = static_cast<char>(uvalue % 10 + '0');
+      uvalue /= 10;
+    } while (uvalue);
+    break;
+
+  case 16:
+    do {
+      *--rnext = impl::to_chars_digits[uvalue & 0xf];
+      uvalue >>= 4;
+    } while (uvalue);
+    break;
+
+    // Generic path
+  default:
+    do {
+      *--rnext = impl::to_chars_digits[uvalue % base];
+      uvalue /= base;
+    } while (uvalue);
+    break;
+  }
+
+  ptrdiff_t str_size = psl::end(buf) - rnext;
+  if (str_size > last - first) {
+    return nullptr;
+  }
+
+  memcpy(first, rnext, str_size);
+  return first + str_size;
+}
 
 } // namespace psl
 

--- a/psl/include/psl/charconv.h
+++ b/psl/include/psl/charconv.h
@@ -1,0 +1,51 @@
+/**
+ * @addtogroup psl
+ * @{
+ * @file charconv.h Integer <-> string conversions.
+ */
+
+#pragma once
+
+#include <psl/type_traits.h>
+
+namespace psl {
+
+/**
+ * Represents a status code returned by the character conversion functions.
+ */
+enum class charconv_status {
+  ok,
+  overflow,
+  invalid_arg,
+};
+
+/**
+ * Result returned by to_chars.
+ */
+struct to_chars_result {
+  char* ptr;              ///< Indicates the end of the formatted number.
+  charconv_status status; ///< Status code.
+};
+
+
+/**
+ * Convert an integer value into a character string and store it in `[begin,
+ * end)`.
+ * @param begin Pointer to the start of the result buffer.
+ * @param end Pointer past the end of the result buffer.
+ * @param value Value to convert.
+ * @param base Numerical base to use. Must be between 2 and 36.
+ * @return On success, a result with @ref psl::to_chars_result::status "status"
+ * set to `ok` and @ref psl::to_chars_result::ptr "ptr"
+ * set past the end of the formatted number. On error, a result with @ref
+ * psl::to_chars_result::status "status" set to the appropriate error code and
+ * @ref psl::to_chars_result::ptr "ptr" set to `end`.
+ * @note This function only participates in overload resolution if `I` is an
+ * integer type.
+ */
+template <typename I, typename = enable_if_t<is_integral_v<I>>>
+to_chars_result to_chars(char* begin, char* end, I value, int base = 10) {}
+
+} // namespace psl
+
+/** @} */

--- a/psl/include/psl/charconv.h
+++ b/psl/include/psl/charconv.h
@@ -38,8 +38,10 @@ char* to_chars(char* first, char* last, I value, int base = 10) {
 
   if constexpr (is_signed_v<I>) {
     if (value < 0) {
-      // No need to check here since [first, last) is required to be a valid
-      // range.
+      if (first == last) {
+        return nullptr;
+      }
+
       *first++ = '-';
       uvalue = -value;
     }

--- a/psl/include/psl/charconv.h
+++ b/psl/include/psl/charconv.h
@@ -34,14 +34,14 @@ constexpr char to_chars_digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
  */
 template <typename I, typename = enable_if_t<is_integral_v<I>>>
 char* to_chars(char* first, char* last, I value, int base = 10) {
-  auto uvalue = static_cast<psl::make_unsigned_t<I>>(value);
+  if (first == last) {
+    return nullptr;
+  }
+
+  auto uvalue = static_cast<make_unsigned_t<I>>(value);
 
   if constexpr (is_signed_v<I>) {
     if (value < 0) {
-      if (first == last) {
-        return nullptr;
-      }
-
       *first++ = '-';
       uvalue = -value;
     }
@@ -76,13 +76,13 @@ char* to_chars(char* first, char* last, I value, int base = 10) {
     break;
   }
 
-  ptrdiff_t str_size = psl::end(buf) - rnext;
-  if (str_size > last - first) {
+  ptrdiff_t digits = psl::end(buf) - rnext;
+  if (digits > last - first) {
     return nullptr;
   }
 
-  memcpy(first, rnext, str_size);
-  return first + str_size;
+  memcpy(first, rnext, digits);
+  return first + digits;
 }
 
 } // namespace psl

--- a/psl/include/psl/charconv.h
+++ b/psl/include/psl/charconv.h
@@ -31,14 +31,16 @@ constexpr char to_chars_digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
  * @return On success, a pointer past the end of the converted integer. On error
  * (if the buffer is too small), returns `nullptr`.
  * @note This function does not null terminate the output buffer.
+ * @note This function only participates in overload resolution if `I` is an
+ * integer type other than `bool`.
  */
-template <typename I, typename = enable_if_t<is_integral_v<I>>>
+template <typename I, typename U = make_unsigned_t<I>>
 char* to_chars(char* first, char* last, I value, int base = 10) {
   if (first == last) {
     return nullptr;
   }
 
-  auto uvalue = static_cast<make_unsigned_t<I>>(value);
+  auto uvalue = static_cast<U>(value);
 
   if constexpr (is_signed_v<I>) {
     if (value < 0) {

--- a/psl/include/psl/format.h
+++ b/psl/include/psl/format.h
@@ -222,6 +222,17 @@ struct formatter<T, enable_if_t<is_convertible_v<T, string_view>>> {
 };
 
 /**
+ * @ref psl_fmt_formatter_builtin "Built-in formatter" for characters.
+ */
+template <>
+struct formatter<char> {
+  template <typename O>
+  static void format(O& output_sink, char c, string_view) {
+    output_sink(string_view{&c, 1});
+  }
+};
+
+/**
  * @ref psl_fmt_formatter_builtin "Built-in formatter" for integer types.
  */
 template <typename I>

--- a/psl/include/psl/format.h
+++ b/psl/include/psl/format.h
@@ -112,9 +112,9 @@ void output_format_arg(O& output_sink, const format_args_ref<O>& args,
 
 /**
  * Opaque type which can be used to reference type-erased formatting arguments
- * created by @ref psl::make_format_args.
+ * created by @ref make_format_args().
  * @note To prevent dangling references, objects of this type should not outlive
- * the formatting argument objects (created by @ref psl::make_format_args) to
+ * the formatting argument objects (created by @ref make_format_args()) to
  * which they refer.
  */
 template <typename O>
@@ -125,7 +125,7 @@ using format_args_ref_t = impl::format_args_ref<type_identity_t<O>>;
  * format suitable for output through @ref psl_fmt_output_sink "output sink"
  * `O`.
  * @note The exact return type of this function is unspecified, but is
- * guaranteed to be convertible to @ref psl::format_args_ref_t.
+ * guaranteed to be convertible to `psl::format_args_ref_t`.
  */
 template <typename O, typename... Args>
 constexpr impl::format_arg_store<O, Args...> make_format_args(
@@ -140,7 +140,7 @@ constexpr impl::format_arg_store<O, Args...> make_format_args(
  * @param output_sink The @ref psl_fmt_output_sink "output sink" to use.
  * @param fmt The @ref psl_fmt_str "format string" to use.
  * @param args A reference to the object holding type-erased formatting
- * arguments. Use @ref psl::make_format_args to create such an object.
+ * arguments. Use @ref make_format_args() to create such an object.
  * @note If the format string is invalid, or if there are more @ref
  * psl_fmt_str_subst "substitutions" in the format string than formatting
  * arguments, the output of this function is unspecified.

--- a/psl/include/psl/format.h
+++ b/psl/include/psl/format.h
@@ -1,0 +1,166 @@
+/**
+ * @addtogroup psl
+ * @{
+ * @file format.h String formatting library.
+ */
+
+#pragma once
+
+#include <psl/algorithm.h>
+#include <psl/string_view.h>
+#include <psl/type_traits.h>
+#include <psl/util.h>
+#include <stddef.h>
+
+namespace psl {
+namespace impl {
+
+template <typename O>
+class format_args_ref;
+
+template <typename O>
+struct format_arg {
+  template <typename T>
+  constexpr format_arg(const T& val)
+      : obj(::psl::addressof(val)),
+        output_func([](O& outputter, const void* obj, string_view spec) {
+          /* ADL */ format_val(outputter, *static_cast<const T*>(obj), spec);
+        }) {}
+
+  const void* obj;
+  void (*output_func)(O&, const void*, string_view);
+};
+
+template <typename O, typename... Args>
+class format_arg_store {
+public:
+  constexpr format_arg_store(const Args&... args) : args_{{args}...} {}
+
+private:
+  friend class format_args_ref<O>;
+
+  format_arg<O> args_[sizeof...(Args)];
+};
+
+
+template <typename O>
+class format_args_ref {
+public:
+  template <typename... Args>
+  constexpr format_args_ref(const format_arg_store<O, Args...>& args)
+      : args_(args.args_), size_(sizeof...(Args)) {}
+
+  template <typename... Args>
+  format_args_ref(const format_arg_store<O, Args...>&&) = delete;
+
+private:
+  template <typename T>
+  friend void output_format_arg(T&, const format_args_ref<T>&, size_t&,
+                                string_view);
+
+  const impl::format_arg<O>* args_;
+  size_t size_;
+};
+
+
+inline string_view extract_prefix(string_view& str, size_t count) {
+  auto ret = str.substr(0, count);
+  str.remove_prefix(count);
+  return ret;
+}
+
+template <typename O>
+bool handle_escaped(O& outputter, string_view& str, char c) {
+  if (!str.empty() && str.front() == c) {
+    str.remove_prefix(1);
+    outputter(string_view{&c, 1});
+    return true;
+  }
+  return false;
+}
+
+template <typename O>
+void output_format_arg(O& outputter, const format_args_ref<O>& args,
+                       size_t& curr_arg, string_view spec) {
+  if (curr_arg >= args.size_) {
+    return;
+  }
+
+  auto user_delim_pos = find(spec.begin(), spec.end(), ':');
+  string_view user_spec = user_delim_pos == spec.end()
+                              ? ""
+                              : spec.substr(user_delim_pos - spec.begin() + 1);
+
+  const auto& arg = args.args_[curr_arg++];
+  arg.output_func(outputter, arg.obj, user_spec);
+}
+
+} // namespace impl
+
+
+template <typename O>
+using format_args_ref_t = impl::format_args_ref<type_identity_t<O>>;
+
+template <typename O, typename... Args>
+constexpr impl::format_arg_store<O, Args...> make_format_args(
+    const Args&... args) {
+  return {args...};
+}
+
+
+template <typename O>
+void vformat(O& outputter, string_view fmt, format_args_ref_t<O> args) {
+  size_t curr_arg = 0;
+
+  while (!fmt.empty()) {
+    auto brace_pos = find_if(fmt.begin(), fmt.end(),
+                             [](char c) { return c == '{' || c == '}'; });
+    auto brace_off = brace_pos - fmt.begin();
+    outputter(impl::extract_prefix(fmt, brace_off));
+
+    if (fmt.empty()) {
+      // Nothing more to do
+      break;
+    }
+
+    fmt.remove_prefix(1); // Skip brace character
+
+    switch (*brace_pos) {
+    case '{':
+      if (impl::handle_escaped(outputter, fmt, '{')) {
+        break;
+      }
+
+      {
+        auto close_brace_pos = find(fmt.begin(), fmt.end(), '}');
+        if (close_brace_pos == fmt.end()) {
+          // Invalid format string
+          return;
+        }
+
+        auto spec = impl::extract_prefix(fmt, close_brace_pos - fmt.begin());
+        fmt.remove_prefix(1); // Skip '}'
+        impl::output_format_arg(outputter, args, curr_arg, spec);
+      }
+
+      break;
+
+    case '}':
+      if (!impl::handle_escaped(outputter, fmt, '}')) {
+        // Invalid format string
+        return;
+      }
+      break;
+    }
+  }
+}
+
+template <typename O, typename... Args>
+void format(O& outputter, string_view fmt, const Args&... args) {
+  auto erased_args = make_format_args<O>(args...);
+  vformat(outputter, fmt, erased_args);
+}
+
+} // namespace psl
+
+/** @} */

--- a/psl/include/psl/format.h
+++ b/psl/include/psl/format.h
@@ -254,6 +254,18 @@ struct formatter<I, enable_if_t<is_integral_v<I>>> {
 };
 
 /**
+ * @ref psl_fmt_formatter_builtin "Built-in formatter" for booleans.
+ */
+template <>
+struct formatter<bool> {
+  template <typename O>
+  static void format(O& output_sink, bool val, string_view) {
+    using namespace literals;
+    output_sink(val ? "true"_sv : "false"_sv);
+  }
+};
+
+/**
  * @ref psl_fmt_formatter_builtin "Built-in formatter" for `nullptr_t`.
  */
 template <>

--- a/psl/include/psl/format.h
+++ b/psl/include/psl/format.h
@@ -1,7 +1,8 @@
 /**
  * @addtogroup psl
  * @{
- * @file format.h String formatting library.
+ * @file format.h String formatting library. For more details, see the @ref
+ * psl_fmt "formatting documentation".
  */
 
 #pragma once
@@ -14,6 +15,12 @@
 
 namespace psl {
 
+/**
+ * Class template that can be specialized to provide formatting capabilities for
+ * custom types. The second template argument defaults to void and can be used
+ * for SFINAE in partial specializations. For more details, see the @ref
+ * psl_fmt_formatter "formatter documentation".
+ */
 template <typename T, typename = void>
 struct formatter;
 
@@ -28,8 +35,8 @@ struct format_arg {
   template <typename T>
   constexpr format_arg(const T& val)
       : obj(::psl::addressof(val)),
-        output_func([](O& outputter, const void* obj, string_view spec) {
-          formatter<T>::format(outputter, *static_cast<T*>(obj), spec);
+        output_func([](O& output_sink, const void* obj, string_view spec) {
+          formatter<T>::format(output_sink, *static_cast<T*>(obj), spec);
         }) {}
 
   const void* obj;
@@ -55,9 +62,6 @@ public:
   constexpr format_args_ref(const format_arg_store<O, Args...>& args)
       : args_(args.args_), size_(sizeof...(Args)) {}
 
-  template <typename... Args>
-  format_args_ref(const format_arg_store<O, Args...>&&) = delete;
-
 private:
   template <typename T>
   friend void output_format_arg(T&, const format_args_ref<T>&, size_t&,
@@ -75,17 +79,17 @@ inline string_view extract_prefix(string_view& str, size_t count) {
 }
 
 template <typename O>
-bool handle_escaped(O& outputter, string_view& str, char c) {
+bool handle_escaped(O& output_sink, string_view& str, char c) {
   if (!str.empty() && str.front() == c) {
     str.remove_prefix(1);
-    outputter(string_view{&c, 1});
+    output_sink(string_view{&c, 1});
     return true;
   }
   return false;
 }
 
 template <typename O>
-void output_format_arg(O& outputter, const format_args_ref<O>& args,
+void output_format_arg(O& output_sink, const format_args_ref<O>& args,
                        size_t& curr_arg, string_view spec) {
   if (curr_arg >= args.size_) {
     return;
@@ -97,15 +101,29 @@ void output_format_arg(O& outputter, const format_args_ref<O>& args,
                               : spec.substr(user_delim_pos - spec.begin() + 1);
 
   const auto& arg = args.args_[curr_arg++];
-  arg.output_func(outputter, arg.obj, user_spec);
+  arg.output_func(output_sink, arg.obj, user_spec);
 }
 
 } // namespace impl
 
 
+/**
+ * Opaque type which can be used to reference type-erased formatting arguments
+ * created by @ref psl::make_format_args.
+ * @note To prevent dangling references, objects of this type should not outlive
+ * the formatting argument objects (created by @ref psl::make_format_args) to
+ * which they refer.
+ */
 template <typename O>
 using format_args_ref_t = impl::format_args_ref<type_identity_t<O>>;
 
+/**
+ * Create a type-erased object storing references to formatting arguments in a
+ * format suitable for output through @ref psl_fmt_output_sink "output sink"
+ * `O`.
+ * @note The exact return type of this function is unspecified, but is
+ * guaranteed to be convertible to @ref psl::format_args_ref_t.
+ */
 template <typename O, typename... Args>
 constexpr impl::format_arg_store<O, Args...> make_format_args(
     const Args&... args) {
@@ -113,15 +131,26 @@ constexpr impl::format_arg_store<O, Args...> make_format_args(
 }
 
 
+/**
+ * Format the @ref psl_fmt_str "format string" `fmt` with the type-erased
+ * arguments stored in `args`, reporting output to `output_sink`.
+ * @param output_sink The @ref psl_fmt_output_sink "output sink" to use.
+ * @param fmt The @ref psl_fmt_str "format string" to use.
+ * @param args A reference to the object holding type-erased formatting
+ * arguments. Use @ref psl::make_format_args to create such an object.
+ * @note If the format string is invalid, or if there are more @ref
+ * psl_fmt_str_subst "substitutions" in the format string than formatting
+ * arguments, the output of this function is unspecified.
+ */
 template <typename O>
-void vformat(O& outputter, string_view fmt, format_args_ref_t<O> args) {
+void vformat(O& output_sink, string_view fmt, format_args_ref_t<O> args) {
   size_t curr_arg = 0;
 
   while (!fmt.empty()) {
     auto brace_pos = find_if(fmt.begin(), fmt.end(),
                              [](char c) { return c == '{' || c == '}'; });
     auto brace_off = brace_pos - fmt.begin();
-    outputter(impl::extract_prefix(fmt, brace_off));
+    output_sink(impl::extract_prefix(fmt, brace_off));
 
     if (fmt.empty()) {
       // Nothing more to do
@@ -132,7 +161,7 @@ void vformat(O& outputter, string_view fmt, format_args_ref_t<O> args) {
 
     switch (*brace_pos) {
     case '{':
-      if (impl::handle_escaped(outputter, fmt, '{')) {
+      if (impl::handle_escaped(output_sink, fmt, '{')) {
         break;
       }
 
@@ -145,13 +174,13 @@ void vformat(O& outputter, string_view fmt, format_args_ref_t<O> args) {
 
         auto spec = impl::extract_prefix(fmt, close_brace_pos - fmt.begin());
         fmt.remove_prefix(1); // Skip '}'
-        impl::output_format_arg(outputter, args, curr_arg, spec);
+        impl::output_format_arg(output_sink, args, curr_arg, spec);
       }
 
       break;
 
     case '}':
-      if (!impl::handle_escaped(outputter, fmt, '}')) {
+      if (!impl::handle_escaped(output_sink, fmt, '}')) {
         // Invalid format string
         return;
       }
@@ -160,10 +189,19 @@ void vformat(O& outputter, string_view fmt, format_args_ref_t<O> args) {
   }
 }
 
+/**
+ * Format the @ref psl_fmt_str "format string" `fmt` with the arguments `args`,
+ * reporting output to `output_sink`.
+ * @param output_sink The @ref psl_fmt_output_sink "output sink" to use.
+ * @param fmt The @ref psl_fmt_str "format string" to use.
+ * @param args The formatting arguments to use.
+ * @note If the format string is invalid, or if there are more @ref
+ * psl_fmt_str_subst "substitutions" in the format string than formatting
+ * arguments, the output of this function is unspecified.
+ */
 template <typename O, typename... Args>
-void format(O& outputter, string_view fmt, const Args&... args) {
-  auto erased_args = make_format_args<O>(args...);
-  vformat(outputter, fmt, erased_args);
+void format(O& output_sink, string_view fmt, const Args&... args) {
+  vformat(output_sink, fmt, make_format_args<O>(args...));
 }
 
 } // namespace psl

--- a/psl/include/psl/format.h
+++ b/psl/include/psl/format.h
@@ -13,6 +13,11 @@
 #include <stddef.h>
 
 namespace psl {
+
+template <typename T, typename = void>
+struct formatter;
+
+
 namespace impl {
 
 template <typename O>
@@ -24,7 +29,7 @@ struct format_arg {
   constexpr format_arg(const T& val)
       : obj(::psl::addressof(val)),
         output_func([](O& outputter, const void* obj, string_view spec) {
-          /* ADL */ format_val(outputter, *static_cast<const T*>(obj), spec);
+          formatter<T>::format(outputter, *static_cast<T*>(obj), spec);
         }) {}
 
   const void* obj;

--- a/psl/include/psl/format.h
+++ b/psl/include/psl/format.h
@@ -210,6 +210,9 @@ void format(O& output_sink, string_view fmt, const Args&... args) {
 
 // Built-in formatters
 
+/**
+ * @ref psl_fmt_formatter_builtin "Built-in formatter" for string types.
+ */
 template <typename T>
 struct formatter<T, enable_if_t<is_convertible_v<T, string_view>>> {
   template <typename O>
@@ -218,6 +221,9 @@ struct formatter<T, enable_if_t<is_convertible_v<T, string_view>>> {
   }
 };
 
+/**
+ * @ref psl_fmt_formatter_builtin "Built-in formatter" for integer types.
+ */
 template <typename I>
 struct formatter<I, enable_if_t<is_integral_v<I>>> {
   template <typename O>
@@ -233,6 +239,9 @@ struct formatter<I, enable_if_t<is_integral_v<I>>> {
   }
 };
 
+/**
+ * @ref psl_fmt_formatter_builtin "Built-in formatter" for `nullptr_t`.
+ */
 template <>
 struct formatter<nullptr_t> {
   template <typename O>
@@ -242,6 +251,9 @@ struct formatter<nullptr_t> {
   }
 };
 
+/**
+ * @ref psl_fmt_formatter_builtin "Built-in formatter" for void pointers.
+ */
 template <typename T>
 struct formatter<T*, enable_if_t<is_void_v<T>>> {
   template <typename O>

--- a/psl/include/psl/format.h
+++ b/psl/include/psl/format.h
@@ -128,7 +128,7 @@ using format_args_ref_t = impl::format_args_ref<type_identity_t<O>>;
  * format suitable for output through @ref psl_fmt_output_sink "output sink"
  * `O`.
  * @note The exact return type of this function is unspecified, but is
- * guaranteed to be convertible to `psl::format_args_ref_t`.
+ * guaranteed to be convertible to `psl::format_args_ref_t<O>`.
  */
 template <typename O, typename... Args>
 constexpr impl::format_arg_store<O, sizeof...(Args)> make_format_args(

--- a/psl/include/psl/string_view.h
+++ b/psl/include/psl/string_view.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <psl/numeric.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -93,6 +94,34 @@ public:
    * @return The i'th character of the stored string.
    */
   constexpr const char& operator[](size_t i) const { return ptr_[i]; }
+
+
+  /**
+   * Retrieve a view of the substring `[pos, min(size(), pos + count))`.
+   * @param pos Position of start of substring.
+   * @param count Requested size. The returned substring may be shorter if the
+   * original string is not long enough.
+   * @return View of the requested substring.
+   * @note The behavior is undefined if `pos > size()`.
+   */
+  constexpr string_view substr(size_t pos, size_t count = -1) {
+    return {ptr_ + pos, min(count, size_ - pos)};
+  }
+
+  /**
+   * Advance the start of the view forward by `n` characters.
+   * @note The behavior is undefined if `n > size()`.
+   */
+  constexpr void remove_prefix(size_t n) {
+    ptr_ += n;
+    size_ -= n;
+  }
+
+  /**
+   * Move the end of the view back by `n` characters.
+   * @note The behavior is undefined if `n > size()`.
+   */
+  constexpr void remove_suffix(size_t n) { size_ -= n; }
 
 private:
   const char* ptr_ = nullptr;

--- a/psl/include/psl/type_traits.h
+++ b/psl/include/psl/type_traits.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 namespace psl {
 
 /**
@@ -297,6 +299,26 @@ constexpr bool is_same_v<T, T> = true;
  */
 template <typename T, typename U>
 struct is_same : bool_constant<is_same_v<T, U>> {};
+
+
+/**
+ * `true` iff `T` is a (bounded or unbounded) array type.
+ */
+template <typename T>
+constexpr bool is_array_v = false;
+
+template <typename T>
+constexpr bool is_array_v<T[]> = true;
+
+template <typename T, size_t N>
+constexpr bool is_array_v<T[N]> = true;
+
+/**
+ * Derives from `true_type` iff `T` is a (bounded or unbounded) array type.
+ * Otherwise, derives from `false_type`.
+ */
+template <typename T>
+struct is_array : bool_constant<is_array_v<T>> {};
 
 
 namespace impl {

--- a/psl/include/psl/type_traits.h
+++ b/psl/include/psl/type_traits.h
@@ -302,6 +302,20 @@ struct is_same : bool_constant<is_same_v<T, U>> {};
 
 
 /**
+ * `true` iff `T` is (cv-qualified) void.
+ */
+template <typename T>
+constexpr bool is_void_v = is_same_v<remove_cv_t<T>, void>;
+
+/**
+ * Derives from `true_type` iff `T` is (cv-qualified) void.
+ * Otherwise, derives from `false_type`.
+ */
+template <typename T>
+struct is_void : bool_constant<is_void_v<T>> {};
+
+
+/**
  * `true` iff `T` is a (bounded or unbounded) array type.
  */
 template <typename T>

--- a/psl/include/psl/type_traits.h
+++ b/psl/include/psl/type_traits.h
@@ -327,6 +327,40 @@ struct is_integral : impl::is_integral<remove_cv_t<T>> {};
 template <typename T>
 constexpr bool is_integral_v = is_integral<T>::value;
 
+
+/**
+ * `true` iff `T` is a signed integer type.
+ */
+template <typename T, bool = is_integral_v<T>>
+constexpr bool is_signed_v = T(-1) < T(0);
+
+template <typename T>
+constexpr bool is_signed_v<T, false> = false;
+
+/**
+ * Derives from `true_type` iff `T` is a signed integer type. Otherwise, derives
+ * from `false_type`.
+ */
+template <typename T>
+struct is_signed : bool_constant<is_signed_v<T>> {};
+
+
+/**
+ * `true` iff `T` is an unsigned integer type. Otherwise, derives from
+ * `false_type`.
+ */
+template <typename T, bool = is_integral_v<T>>
+constexpr bool is_unsigned_v = T(-1) > T(0);
+
+template <typename T>
+constexpr bool is_unsigned_v<T, false> = false;
+
+/**
+ * Derives from `true_type` iff `T` is an unsigned integer type.
+ */
+template <typename T>
+struct is_unsigned : bool_constant<is_unsigned_v<T>> {};
+
 } // namespace psl
 
 /** @} */

--- a/psl/include/psl/type_traits.h
+++ b/psl/include/psl/type_traits.h
@@ -2,7 +2,7 @@
  * @addtogroup psl
  * @{
  * @file type_traits.h Partial implementation of the standard
- * &lt;type_traits&gt; header.
+ * &lt;type_traits&gt; header, with psl-specific bits.
  */
 
 #pragma once
@@ -113,6 +113,30 @@ using remove_cv_t = remove_volatile_t<remove_const_t<T>>;
  */
 template <typename T>
 struct remove_cv : type_identity<remove_cv_t<T>> {};
+
+
+/**
+ * Provide a member alias `type` equivalent to `U` with any of `T`'s
+ * cv-qualifiers applied to it.
+ * @note This metafunction is psl-specific.
+ */
+template <typename T, typename U>
+struct apply_cv : type_identity<U> {};
+
+template <typename T, typename U>
+struct apply_cv<const T, U> : type_identity<const U> {};
+
+template <typename T, typename U>
+struct apply_cv<volatile T, U> : type_identity<volatile U> {};
+
+template <typename T, typename U>
+struct apply_cv<const volatile T, U> : type_identity<const volatile U> {};
+
+/**
+ * Helper alias for using apply_cv.
+ */
+template <typename T, typename U>
+using apply_cv_t = typename apply_cv<T, U>::type;
 
 
 /**
@@ -360,6 +384,7 @@ constexpr bool is_unsigned_v<T, false> = false;
  */
 template <typename T>
 struct is_unsigned : bool_constant<is_unsigned_v<T>> {};
+
 
 } // namespace psl
 

--- a/psl/include/psl/type_traits.h
+++ b/psl/include/psl/type_traits.h
@@ -321,6 +321,26 @@ template <typename T>
 struct is_array : bool_constant<is_array_v<T>> {};
 
 
+/**
+ * `true` iff `T` is an lvalue or rvalue reference type.
+ */
+template <typename T>
+constexpr bool is_reference_v = false;
+
+template <typename T>
+constexpr bool is_reference_v<T&> = true;
+
+template <typename T>
+constexpr bool is_reference_v<T&&> = true;
+
+/**
+ * Derives from `true_type` iff `T` is an lvalue or rvalue reference type.
+ * Otherwise, derives from `false_type`.
+ */
+template <typename T>
+struct is_reference : bool_constant<is_reference_v<T>> {};
+
+
 namespace impl {
 
 template <typename T>

--- a/psl/include/psl/type_traits.h
+++ b/psl/include/psl/type_traits.h
@@ -386,6 +386,92 @@ template <typename T>
 struct is_unsigned : bool_constant<is_unsigned_v<T>> {};
 
 
+namespace impl {
+
+template <typename T>
+constexpr bool is_nonbool_integral_v =
+    is_integral_v<T> && !is_same_v<remove_cv_t<T>, bool>;
+
+
+template <typename T>
+struct make_signed : type_identity<T> {};
+
+template <>
+struct make_signed<char> : type_identity<signed char> {};
+template <>
+struct make_signed<unsigned char> : type_identity<signed char> {};
+template <>
+struct make_signed<unsigned short> : type_identity<short> {};
+template <>
+struct make_signed<unsigned int> : type_identity<int> {};
+template <>
+struct make_signed<unsigned long> : type_identity<long> {};
+template <>
+struct make_signed<unsigned long long> : type_identity<long long> {};
+
+template <typename T>
+using make_signed_t = typename make_signed<T>::type;
+
+
+template <typename T>
+struct make_unsigned : type_identity<T> {};
+
+template <>
+struct make_unsigned<char> : type_identity<unsigned char> {};
+template <>
+struct make_unsigned<signed char> : type_identity<unsigned char> {};
+template <>
+struct make_unsigned<short> : type_identity<unsigned short> {};
+template <>
+struct make_unsigned<int> : type_identity<unsigned int> {};
+template <>
+struct make_unsigned<long> : type_identity<unsigned long> {};
+template <>
+struct make_unsigned<long long> : type_identity<unsigned long long> {};
+
+template <typename T>
+using make_unsigned_t = typename make_unsigned<T>::type;
+
+} // namespace impl
+
+
+/**
+ * If `T` is an integer type that is not `bool`, provide a member alias `type`
+ * corresponding to the signed variant of `T`. `T`'s cv-qualifiers are
+ * preserved.
+ */
+template <typename T, bool = impl::is_nonbool_integral_v<T>>
+struct make_signed {};
+
+template <typename T>
+struct make_signed<T, true>
+    : type_identity<apply_cv_t<T, impl::make_signed_t<T>>> {};
+
+/**
+ * Helper alias for using make_unsigned.
+ */
+template <typename T>
+using make_signed_t = typename make_signed<T>::type;
+
+
+/**
+ * If `T` is an integer type that is not `bool`, provide a member alias `type`
+ * corresponding to the unsigned variant of `T`. `T`'s cv-qualifiers are
+ * preserved.
+ */
+template <typename T, bool = impl::is_nonbool_integral_v<T>>
+struct make_unsigned {};
+
+template <typename T>
+struct make_unsigned<T, true>
+    : type_identity<apply_cv_t<T, impl::make_unsigned_t<T>>> {};
+
+/**
+ * Helper alias for using make_unsigned.
+ */
+template <typename T>
+using make_unsigned_t = typename make_unsigned<T>::type;
+
 } // namespace psl
 
 /** @} */

--- a/psl/include/psl/type_traits.h
+++ b/psl/include/psl/type_traits.h
@@ -375,6 +375,20 @@ template <typename T>
 struct is_volatile : bool_constant<is_volatile_v<T>> {};
 
 
+/**
+ * `true` iff `T` is a function type.
+ */
+template <typename T>
+constexpr bool is_function_v = !is_reference_v<T> && !is_const_v<const T>;
+
+/**
+ * Derives from `true_type` iff `T` is a function type.
+ * Otherwise, derives from `false_type`.
+ */
+template <typename T>
+struct is_function : bool_constant<is_function_v<T>> {};
+
+
 namespace impl {
 
 template <typename T>

--- a/psl/include/psl/type_traits.h
+++ b/psl/include/psl/type_traits.h
@@ -405,6 +405,40 @@ struct is_function : bool_constant<is_function_v<T>> {};
 
 namespace impl {
 
+template <typename To>
+void try_convert(To);
+
+template <typename From, typename To, typename = void>
+constexpr bool is_convertible_test_v = false;
+
+template <typename From, typename To>
+constexpr bool is_convertible_test_v<
+    From, To, decltype(::psl::impl::try_convert<To>(declval<From>()))> = true;
+
+} // namespace impl
+
+
+/**
+ * `true` iff `From` is implicitly convertible to `To`.
+ */
+template <typename From, typename To,
+          bool = is_void_v<From> || is_array_v<To> || is_function_v<To>>
+constexpr bool is_convertible_v = is_void_v<To>;
+
+template <typename From, typename To>
+constexpr bool is_convertible_v<From, To, false> =
+    impl::is_convertible_test_v<From, To>;
+
+/**
+ * Derives from `true_type` iff `From` is implicitly convertible to `To`.
+ * Otherwise, derives from `false_type`.
+ */
+template <typename From, typename To>
+struct is_convertible : bool_constant<is_convertible_v<From, To>> {};
+
+
+namespace impl {
+
 template <typename T>
 struct is_integral : false_type {};
 

--- a/psl/include/psl/type_traits.h
+++ b/psl/include/psl/type_traits.h
@@ -341,6 +341,40 @@ template <typename T>
 struct is_reference : bool_constant<is_reference_v<T>> {};
 
 
+/**
+ * `true` iff `T` is a const-qualified type.
+ */
+template <typename T>
+constexpr bool is_const_v = false;
+
+template <typename T>
+constexpr bool is_const_v<const T> = true;
+
+/**
+ * Derives from `true_type` iff `T` is an const-qualified type.
+ * Otherwise, derives from `false_type`.
+ */
+template <typename T>
+struct is_const : bool_constant<is_const_v<T>> {};
+
+
+/**
+ * `true` iff `T` is a volatile-qualified type.
+ */
+template <typename T>
+constexpr bool is_volatile_v = false;
+
+template <typename T>
+constexpr bool is_volatile_v<volatile T> = true;
+
+/**
+ * Derives from `true_type` iff `T` is an volatile-qualified type.
+ * Otherwise, derives from `false_type`.
+ */
+template <typename T>
+struct is_volatile : bool_constant<is_volatile_v<T>> {};
+
+
 namespace impl {
 
 template <typename T>

--- a/psl/include/psl/type_traits.h
+++ b/psl/include/psl/type_traits.h
@@ -508,8 +508,7 @@ struct is_signed : bool_constant<is_signed_v<T>> {};
 
 
 /**
- * `true` iff `T` is an unsigned integer type. Otherwise, derives from
- * `false_type`.
+ * `true` iff `T` is an unsigned integer type.
  */
 template <typename T, bool = is_integral_v<T>>
 constexpr bool is_unsigned_v = T(-1) > T(0);

--- a/psl/include/psl/util.h
+++ b/psl/include/psl/util.h
@@ -113,6 +113,21 @@ constexpr byte& operator^=(byte& lhs, byte rhs) {
   return lhs = lhs ^ rhs;
 }
 
+
+/**
+ * Compute the address of `obj`, even in the presence of overloaded `operator&`.
+ */
+template <typename T>
+constexpr T* addressof(T& obj) {
+  return __builtin_addressof(obj);
+}
+
+/**
+ * Ensure that rvalues cannot have their address taken.
+ */
+template <typename T>
+const T* addressof(const T&&) = delete;
+
 } // namespace psl
 
 /** @} */

--- a/psl/include/psl/util.h
+++ b/psl/include/psl/util.h
@@ -11,6 +11,8 @@
 
 namespace psl {
 
+using nullptr_t = decltype(nullptr);
+
 /**
  * Byte type inspired by `std::byte`. Prefer this type to integer types when
  * performing byte-level access on objects. This type is not an integer, but can


### PR DESCRIPTION
The library provides a type-safe, extensible API inspired by [{fmt}](https://fmt.dev).

Beyond the formatting library, various other core library features were implemented as they were needed:
* Additional type traits
* Additional `string_view` member functions
* &lt;algorithm&gt; `find` and `find_if`
* `to_chars` for integers
* `addressof`
* `nullptr_t`