### PR TITLE
Create kernel logging library

### DIFF
--- a/kernel/arch/x86_64/console.cpp
+++ b/kernel/arch/x86_64/console.cpp
@@ -91,6 +91,13 @@ constexpr size_t console_rows = 25;
  */
 constexpr size_t console_cols = 80;
 
+struct impl_console_write_handler : public log::write_handler {
+  constexpr impl_console_write_handler() = default;
+  void write(psl::string_view str) { console_puts(str); }
+};
+
+struct impl_console_write_handler console_write_handler =
+    impl_console_write_handler{};
 
 /**
  * Current row in the console.
@@ -101,7 +108,6 @@ size_t curr_row;
  * Current column in the console
  */
 size_t curr_col;
-
 
 /**
  * Enable the VGA cursor
@@ -244,6 +250,10 @@ void console_puts(psl::string_view str) {
     do_putc(c);
   }
   update_cursor();
+}
+
+void console_log_init() {
+  log::set_write_handler(&console_write_handler);
 }
 
 } // namespace arch

--- a/kernel/arch/x86_64/console.cpp
+++ b/kernel/arch/x86_64/console.cpp
@@ -98,7 +98,10 @@ constexpr size_t console_cols = 80;
  */
 struct console_write_handler : public log::write_handler {
   constexpr console_write_handler() = default;
-  void write(psl::string_view str) override { console_puts(str); }
+  void write(psl::string_view str) override {
+    console_puts(str);
+    console_putc('\n');
+  }
 };
 
 

--- a/kernel/arch/x86_64/console.cpp
+++ b/kernel/arch/x86_64/console.cpp
@@ -7,6 +7,7 @@
 #include <arch/console.h>
 
 #include <arch/x86_64/ioport.h>
+#include <lib/log.h>
 #include <mm/phys.h>
 
 #include <stdint.h>
@@ -95,16 +96,11 @@ constexpr size_t console_cols = 80;
 /**
  * Implementation of @ref log::write_handler for the console.
  */
-struct impl_console_write_handler : public log::write_handler {
-  constexpr impl_console_write_handler() = default;
-  void write(psl::string_view str) { console_puts(str); }
+struct console_write_handler : public log::write_handler {
+  constexpr console_write_handler() = default;
+  void write(psl::string_view str) override { console_puts(str); }
 };
 
-/**
- * @ref log::write_handler derived instance for the console
- */
-struct impl_console_write_handler console_write_handler =
-    impl_console_write_handler{};
 
 /**
  * Current row in the console.
@@ -259,8 +255,9 @@ void console_puts(psl::string_view str) {
   update_cursor();
 }
 
-void console_log_init() {
-  log::set_write_handler(&console_write_handler);
+void console_install_log_handler() {
+  static /* constinit */ console_write_handler handler{};
+  log::set_write_handler(&handler);
 }
 
 } // namespace arch

--- a/kernel/arch/x86_64/console.cpp
+++ b/kernel/arch/x86_64/console.cpp
@@ -91,11 +91,18 @@ constexpr size_t console_rows = 25;
  */
 constexpr size_t console_cols = 80;
 
+
+/**
+ * Implementation of @ref log::write_handler for the console.
+ */
 struct impl_console_write_handler : public log::write_handler {
   constexpr impl_console_write_handler() = default;
   void write(psl::string_view str) { console_puts(str); }
 };
 
+/**
+ * @ref log::write_handler derived instance for the console
+ */
 struct impl_console_write_handler console_write_handler =
     impl_console_write_handler{};
 

--- a/kernel/arch/x86_64/include/arch/console.h
+++ b/kernel/arch/x86_64/include/arch/console.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <lib/log.h>
 #include <psl/string_view.h>
 
 namespace arch {
@@ -36,10 +35,10 @@ void console_puts(psl::string_view str);
 
 
 /**
- * Initialize logging for the console. Sets write handler for logging library
- * implementation.
+ * Install a @ref log::write_handler "logging write handler" that redirects
+ * output to the console.
  */
-void console_log_init();
+void console_install_log_handler();
 
 } // namespace arch
 /** @} */

--- a/kernel/arch/x86_64/include/arch/console.h
+++ b/kernel/arch/x86_64/include/arch/console.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <lib/log.h>
 #include <psl/string_view.h>
 
 namespace arch {
@@ -33,6 +34,7 @@ void console_putc(char c);
  */
 void console_puts(psl::string_view str);
 
-} // namespace arch
+void console_log_init();
 
+} // namespace arch
 /** @} */

--- a/kernel/arch/x86_64/include/arch/console.h
+++ b/kernel/arch/x86_64/include/arch/console.h
@@ -34,6 +34,11 @@ void console_putc(char c);
  */
 void console_puts(psl::string_view str);
 
+
+/**
+ * Initialize logging for the console. Sets write handler for logging library
+ * implementation.
+ */
 void console_log_init();
 
 } // namespace arch

--- a/kernel/arch/x86_64/init.cpp
+++ b/kernel/arch/x86_64/init.cpp
@@ -62,6 +62,7 @@ void early_init() {
   x86_64::init_bsp();
   x86_64::mmu_init_phys_map();
   console_init();
+  console_log_init();
   process_multiboot_info();
 }
 

--- a/kernel/arch/x86_64/init.cpp
+++ b/kernel/arch/x86_64/init.cpp
@@ -8,6 +8,7 @@
 #include <arch/x86_64/mmu.h>
 #include <arch/x86_64/mp.h>
 #include <arch/x86_64/multiboot2.h>
+#include <lib/log.h>
 #include <mm/phys.h>
 
 #include <psl/numeric.h>
@@ -31,9 +32,7 @@ void process_multiboot_tag(uint32_t type, const void* raw_tag) {
   switch (type) {
   case MULTIBOOT_TAG_TYPE_BOOT_LOADER_NAME:
     const auto* tag = static_cast<const multiboot_tag_string*>(raw_tag);
-    console_puts("Booted by: ");
-    console_puts(tag->string);
-    console_putc('\n');
+    log::write("Booted by: {}", tag->string);
     break;
   }
 }

--- a/kernel/arch/x86_64/init.cpp
+++ b/kernel/arch/x86_64/init.cpp
@@ -62,7 +62,7 @@ void early_init() {
   x86_64::init_bsp();
   x86_64::mmu_init_phys_map();
   console_init();
-  console_log_init();
+  console_install_log_handler();
   process_multiboot_info();
 }
 

--- a/kernel/include/lib/log.h
+++ b/kernel/include/lib/log.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/kernel/include/lib/log.h
+++ b/kernel/include/lib/log.h
@@ -1,1 +1,63 @@
+/**
+ * @addtogroup kernel
+ * @{
+ * @file log.h Kernel logging library
+ */
+
 #pragma once
+
+#include <psl/format.h>
+
+namespace log {
+namespace impl {
+
+using fmt_output_sink = psl::range_output_sink<char*>;
+
+/**
+ * Format and send the message to the current write handler.
+ */
+void do_write(psl::string_view fmt,
+              psl::format_args_ref_t<fmt_output_sink> args);
+
+} // namespace impl
+
+
+/**
+ * The maximum size a formatted log message is allowed to have. Messages longer
+ * than this will be truncated.
+ */
+constexpr size_t max_msg_size = 256;
+
+
+/**
+ * Polymorphic base class for objects wishing to handle output of log messages.
+ */
+struct write_handler {
+  /**
+   * Called when a message is written to the log.
+   */
+  virtual void write(psl::string_view msg) = 0;
+};
+
+/**
+ * Set the current write handler to `handler`. If `handler` is non-null, it will
+ * be called every time a message is logged via @ref write().
+ */
+void set_write_handler(write_handler* handler);
+
+/**
+ * Write a @ref psl_fmt "formatted message" to the log. If the current write
+ * handler is null, this is a no-op. If the formatted message is longer than
+ * `max_msg_size`, it will be truncated.
+ * @param fmt The @ref psl_fmt_str "format string" to use.
+ * @param args Formatting arguments.
+ */
+template <typename... Args>
+void write(psl::string_view fmt, const Args&... args) {
+  return impl::do_write(fmt,
+                        psl::make_format_args<impl::fmt_output_sink>(args...));
+}
+
+} // namespace log
+
+/** @} */

--- a/kernel/lib/CMakeLists.txt
+++ b/kernel/lib/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_subdirectory(libc)
+
+target_sources(kernel PRIVATE log.cpp)

--- a/kernel/lib/log.cpp
+++ b/kernel/lib/log.cpp
@@ -1,1 +1,45 @@
+/**
+ * @addtogroup kernel
+ * @{
+ * @file log.cpp Kernel logging library implementation.
+ */
+
 #include <lib/log.h>
+
+namespace log {
+namespace {
+
+/**
+ * The current write handler.
+ * @todo Protect with a spinlock?
+ */
+write_handler* curr_write_handler;
+
+} // namespace
+
+namespace impl {
+
+void do_write(psl::string_view fmt,
+              psl::format_args_ref_t<fmt_output_sink> args) {
+  if (!curr_write_handler) {
+    return;
+  }
+
+  char buf[max_msg_size];
+  fmt_output_sink sink{psl::begin(buf), psl::end(buf)};
+  psl::vformat(sink, fmt, args);
+  size_t formatted_size = sink.cursor() - psl::begin(buf);
+
+  curr_write_handler->write({buf, formatted_size});
+}
+
+} // namespace impl
+
+
+void set_write_handler(write_handler* handler) {
+  curr_write_handler = handler;
+}
+
+} // namespace log
+
+/** } */

--- a/kernel/lib/log.cpp
+++ b/kernel/lib/log.cpp
@@ -1,0 +1,1 @@
+#include <lib/log.h>

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -5,14 +5,14 @@
  */
 
 #include <arch/arch.h>
-#include <arch/console.h>
+#include <lib/log.h>
 
 /**
  * Main kernel entry point.
  */
 extern "C" [[noreturn]] void kernel_main() {
   arch::early_init();
-  arch::console_puts("Welcome to PegasOS!\n");
+  log::write("Welcome to PegasOS!");
   arch::halt();
 }
 


### PR DESCRIPTION
The library supports formatted output (via `psl::format`) and redirection of the logs to arbitrary write handlers (currently, a write handler which logs output to the console is installed for early boot messages).

A new helper function that formats to a character iterator range was also created because it was needed in the library.