### PR TITLE
Set up clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,2 @@
+Checks: 'readability-*,bugprone-*,misc-*,clang-analyzer-*'
+FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
 Checks: 'readability-*,bugprone-*,misc-*,clang-analyzer-*'
-HeaderFilterRegex: '.'
+HeaderFilterRegex: '.*'
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,3 @@
 Checks: 'readability-*,bugprone-*,misc-*,clang-analyzer-*'
+HeaderFilterRegex: '.'
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 # readability-magic-numbers is just too noisy for now
 # TODO: revisit this
-Checks: 'readability-*,-readability-magic-numbers,modernize-use-*,-modernize-use-trailing-return-type,bugprone-*,misc-*,clang-analyzer-*'
+Checks: 'readability-*,-readability-magic-numbers,modernize-use-*,google-readability-casting,-modernize-use-trailing-return-type,bugprone-*,misc-*,clang-analyzer-*'
 HeaderFilterRegex: '.*'
 FormatStyle: file
 CheckOptions:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,5 @@ Checks: 'readability-*,-readability-magic-numbers,modernize-use-nodiscard,bugpro
 HeaderFilterRegex: '.*'
 FormatStyle: file
 CheckOptions:
-  - key: readability-implicit-bool-conversion.AllowIntegerConditions
-    value: '1'
   - key: readability-implicit-bool-conversion.AllowPointerConditions
     value: '1'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,10 @@
-Checks: 'readability-*,bugprone-*,misc-*,clang-analyzer-*'
+# readability-magic-numbers is just too noisy for now
+# TODO: revisit this
+Checks: 'readability-*,-readability-magic-numbers,modernize-use-nodiscard,bugprone-*,misc-*,clang-analyzer-*'
 HeaderFilterRegex: '.*'
 FormatStyle: file
+CheckOptions:
+  - key: readability-implicit-bool-conversion.AllowIntegerConditions
+    value: '1'
+  - key: readability-implicit-bool-conversion.AllowPointerConditions
+    value: '1'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,3 +6,30 @@ FormatStyle: file
 CheckOptions:
   - key: readability-implicit-bool-conversion.AllowPointerConditions
     value: '1'
+
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.ClassCase
+    value: lower_case
+  - key: readability-identifier-naming.TypedefCase
+    value: lower_case
+  - key: readability-identifier-naming.TypeAliasCase
+    value: lower_case
+  - key: readability-identifier-naming.EnumCase
+    value: lower_case
+  - key: readability-identifier-naming.EnumConstantCase
+    value: lower_case
+  - key: readability-identifier-naming.FunctionCase
+    value: lower_case
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key: readability-identifier-naming.MemberCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: _
+  - key: readability-identifier-naming.ProtectedMemberSuffix
+    value: _
+  - key: readability-identifier-naming.TemplateParameterCase
+    value: CamelCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 # readability-magic-numbers is just too noisy for now
 # TODO: revisit this
-Checks: 'readability-*,-readability-magic-numbers,modernize-use-nodiscard,bugprone-*,misc-*,clang-analyzer-*'
+Checks: 'readability-*,-readability-magic-numbers,modernize-use-*,-modernize-use-trailing-return-type,bugprone-*,misc-*,clang-analyzer-*'
 HeaderFilterRegex: '.*'
 FormatStyle: file
 CheckOptions:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ set(PEGASOS_NO_KERNEL_LTO OFF CACHE BOOL "Disable kernel LTO in release builds")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+find_program(CLANG_TIDY clang-tidy)
+if (CLANG_TIDY)
+  set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
+
 add_compile_options(-Wall -Wextra)
 
 add_subdirectory(psl)

--- a/kernel/arch/x86_64/include/arch/x86_64/control_regs.h
+++ b/kernel/arch/x86_64/include/arch/x86_64/control_regs.h
@@ -158,8 +158,8 @@ inline uint64_t read_msr(uint32_t id) {
  * @param value The value to be stored.
  */
 inline void write_msr(uint32_t id, uint64_t value) {
-  uint32_t low = static_cast<uint32_t>(value);
-  uint32_t high = static_cast<uint32_t>(value >> 32);
+  auto low = static_cast<uint32_t>(value);
+  auto high = static_cast<uint32_t>(value >> 32);
 
   asm volatile("wrmsr" : : "c"(id), "d"(high), "a"(low));
 }

--- a/kernel/arch/x86_64/include/arch/x86_64/control_regs.h
+++ b/kernel/arch/x86_64/include/arch/x86_64/control_regs.h
@@ -146,7 +146,8 @@ inline void write_cr4(uint64_t value) {
  * @return Current state of the MSR specified by `id`.
  */
 inline uint64_t read_msr(uint32_t id) {
-  uint32_t low, high;
+  uint32_t low;
+  uint32_t high;
   asm volatile("rdmsr" : "=d"(high), "=a"(low) : "c"(id));
   return static_cast<uint64_t>(high) << 32 | low;
 }

--- a/kernel/arch/x86_64/include/arch/x86_64/multiboot2.h
+++ b/kernel/arch/x86_64/include/arch/x86_64/multiboot2.h
@@ -90,10 +90,10 @@
 
 #ifndef __ASSEMBLER__
 
-typedef unsigned char multiboot_uint8_t;
-typedef unsigned short multiboot_uint16_t;
-typedef unsigned int multiboot_uint32_t;
-typedef unsigned long long multiboot_uint64_t;
+typedef unsigned char multiboot_uint8_t;       // NOLINT: keep c-compatible
+typedef unsigned short multiboot_uint16_t;     // NOLINT: keep c-compatible
+typedef unsigned int multiboot_uint32_t;       // NOLINT: keep c-compatible
+typedef unsigned long long multiboot_uint64_t; // NOLINT: keep c-compatible
 
 struct multiboot_header {
   /*  Must be MULTIBOOT_MAGIC - see above. */
@@ -188,6 +188,7 @@ struct multiboot_mmap_entry {
   multiboot_uint32_t type;
   multiboot_uint32_t zero;
 };
+// NOLINTNEXTLINE: keep c-compatible
 typedef struct multiboot_mmap_entry multiboot_memory_map_t;
 
 struct multiboot_tag {

--- a/kernel/arch/x86_64/init.cpp
+++ b/kernel/arch/x86_64/init.cpp
@@ -53,7 +53,7 @@ void process_multiboot_info() {
     memcpy(&tag, info + processed, sizeof(tag));
     process_multiboot_tag(tag.type, info + processed);
     processed = psl::round_up(processed + tag.size, MULTIBOOT_TAG_ALIGN);
-  } while (tag.type);
+  } while (tag.type != 0U);
 }
 
 } // namespace

--- a/kernel/lib/libc/string.cpp
+++ b/kernel/lib/libc/string.cpp
@@ -54,7 +54,7 @@ void* memset(void* dest, int ch, size_t count) {
 
 size_t strlen(const char* str) {
   size_t len = 0;
-  for (; *str; str++, len++) {
+  for (; *str != 0; str++, len++) {
   }
   return len;
 }

--- a/kernel/lib/libc/string.cpp
+++ b/kernel/lib/libc/string.cpp
@@ -54,7 +54,7 @@ void* memset(void* dest, int ch, size_t count) {
 
 size_t strlen(const char* str) {
   size_t len = 0;
-  for (; *str != 0; str++, len++) {
+  for (; *str != '\0'; str++, len++) {
   }
   return len;
 }

--- a/psl/include/psl/format.h
+++ b/psl/include/psl/format.h
@@ -219,7 +219,7 @@ void format(O& output_sink, string_view fmt, const Args&... args) {
 template <typename T>
 struct formatter<T, enable_if_t<is_convertible_v<T, string_view>>> {
   template <typename O>
-  static void format(O& output_sink, string_view val, string_view) {
+  static void format(O& output_sink, string_view val, string_view /*spec*/) {
     output_sink(val);
   }
 };
@@ -230,7 +230,7 @@ struct formatter<T, enable_if_t<is_convertible_v<T, string_view>>> {
 template <>
 struct formatter<char> {
   template <typename O>
-  static void format(O& output_sink, char c, string_view) {
+  static void format(O& output_sink, char c, string_view /*spec*/) {
     output_sink(string_view{&c, 1});
   }
 };
@@ -259,7 +259,7 @@ struct formatter<I, enable_if_t<is_integral_v<I>>> {
 template <>
 struct formatter<bool> {
   template <typename O>
-  static void format(O& output_sink, bool val, string_view) {
+  static void format(O& output_sink, bool val, string_view /*spec*/) {
     using namespace literals;
     output_sink(val ? "true"_sv : "false"_sv);
   }
@@ -271,7 +271,7 @@ struct formatter<bool> {
 template <>
 struct formatter<nullptr_t> {
   template <typename O>
-  static void format(O& output_sink, nullptr_t, string_view) {
+  static void format(O& output_sink, nullptr_t, string_view /*spec*/) {
     using namespace literals;
     output_sink("nullptr"_sv);
   }
@@ -283,7 +283,7 @@ struct formatter<nullptr_t> {
 template <typename T>
 struct formatter<T*, enable_if_t<is_void_v<T>>> {
   template <typename O>
-  static void format(O& output_sink, T* ptr, string_view) {
+  static void format(O& output_sink, T* ptr, string_view /*spec*/) {
     if (!ptr) {
       return formatter<nullptr_t>::format(output_sink, nullptr, "");
     }

--- a/psl/include/psl/iterator.h
+++ b/psl/include/psl/iterator.h
@@ -22,7 +22,7 @@ constexpr auto size(const C& cont) -> decltype(cont.size()) {
  * @return The size of the specified array.
  */
 template <typename T, size_t N>
-constexpr size_t size(const T (&)[N]) {
+constexpr size_t size(const T (&/*arr*/)[N]) {
   return N;
 }
 

--- a/psl/include/psl/string_view.h
+++ b/psl/include/psl/string_view.h
@@ -43,51 +43,51 @@ public:
   /**
    *  @return An `iterator` pointing to the beginning of the string.
    */
-  constexpr iterator begin() const { return ptr_; }
+  [[nodiscard]] constexpr iterator begin() const { return ptr_; }
 
   /**
    *  @return An `iterator` pointing past the end of the string.
    */
-  constexpr iterator end() const { return ptr_ + size_; }
+  [[nodiscard]] constexpr iterator end() const { return ptr_ + size_; }
 
   /**
    *  @return A `const_iterator` pointing to the beginning of the string.
    */
-  constexpr const_iterator cbegin() const { return ptr_; }
+  [[nodiscard]] constexpr const_iterator cbegin() const { return ptr_; }
 
   /**
    *  @return A `const_iterator` pointing past the end of the string.
    */
-  constexpr const_iterator cend() const { return ptr_ + size_; }
+  [[nodiscard]] constexpr const_iterator cend() const { return ptr_ + size_; }
 
 
   /**
    * @return A pointer to the raw data stored in the string.
    */
-  constexpr const char* data() const { return ptr_; }
+  [[nodiscard]] constexpr const char* data() const { return ptr_; }
 
   /**
    * @return The size of the string.
    */
-  constexpr size_t size() const { return size_; }
+  [[nodiscard]] constexpr size_t size() const { return size_; }
   /**
    * @return The size of the string.
    */
-  constexpr size_t length() const { return size_; }
+  [[nodiscard]] constexpr size_t length() const { return size_; }
   /**
    * @return True if the string is empty.
    */
-  [[nodiscard]] constexpr bool empty() const { return !size_; }
+  [[nodiscard]] constexpr bool empty() const { return size_ == 0; }
 
 
   /**
    * @return The first character of the stored string.
    */
-  constexpr const char& front() const { return ptr_[0]; }
+  [[nodiscard]] constexpr const char& front() const { return ptr_[0]; }
   /**
    * @return The last character of the stored string.
    */
-  constexpr const char& back() const { return ptr_[size_]; }
+  [[nodiscard]] constexpr const char& back() const { return ptr_[size_]; }
   /**
    * @param i The position of the character to return.
    *

--- a/psl/include/psl/type_traits.h
+++ b/psl/include/psl/type_traits.h
@@ -288,10 +288,10 @@ using enable_if_t = typename enable_if<E, T>::type;
  * `true` iff `T` and `U` name the same type.
  */
 template <typename T, typename U>
-constexpr bool is_same_v = false;
+inline constexpr bool is_same_v = false;
 
 template <typename T>
-constexpr bool is_same_v<T, T> = true;
+inline constexpr bool is_same_v<T, T> = true;
 
 /**
  * Derives from `true_type` iff `T` and `U` name the same type. Otherwise,
@@ -305,7 +305,7 @@ struct is_same : bool_constant<is_same_v<T, U>> {};
  * `true` iff `T` is (cv-qualified) void.
  */
 template <typename T>
-constexpr bool is_void_v = is_same_v<remove_cv_t<T>, void>;
+inline constexpr bool is_void_v = is_same_v<remove_cv_t<T>, void>;
 
 /**
  * Derives from `true_type` iff `T` is (cv-qualified) void.
@@ -319,13 +319,13 @@ struct is_void : bool_constant<is_void_v<T>> {};
  * `true` iff `T` is a (bounded or unbounded) array type.
  */
 template <typename T>
-constexpr bool is_array_v = false;
+inline constexpr bool is_array_v = false;
 
 template <typename T>
-constexpr bool is_array_v<T[]> = true;
+inline constexpr bool is_array_v<T[]> = true;
 
 template <typename T, size_t N>
-constexpr bool is_array_v<T[N]> = true;
+inline constexpr bool is_array_v<T[N]> = true;
 
 /**
  * Derives from `true_type` iff `T` is a (bounded or unbounded) array type.
@@ -339,13 +339,13 @@ struct is_array : bool_constant<is_array_v<T>> {};
  * `true` iff `T` is an lvalue or rvalue reference type.
  */
 template <typename T>
-constexpr bool is_reference_v = false;
+inline constexpr bool is_reference_v = false;
 
 template <typename T>
-constexpr bool is_reference_v<T&> = true;
+inline constexpr bool is_reference_v<T&> = true;
 
 template <typename T>
-constexpr bool is_reference_v<T&&> = true;
+inline constexpr bool is_reference_v<T&&> = true;
 
 /**
  * Derives from `true_type` iff `T` is an lvalue or rvalue reference type.
@@ -359,10 +359,10 @@ struct is_reference : bool_constant<is_reference_v<T>> {};
  * `true` iff `T` is a const-qualified type.
  */
 template <typename T>
-constexpr bool is_const_v = false;
+inline constexpr bool is_const_v = false;
 
 template <typename T>
-constexpr bool is_const_v<const T> = true;
+inline constexpr bool is_const_v<const T> = true;
 
 /**
  * Derives from `true_type` iff `T` is an const-qualified type.
@@ -376,10 +376,10 @@ struct is_const : bool_constant<is_const_v<T>> {};
  * `true` iff `T` is a volatile-qualified type.
  */
 template <typename T>
-constexpr bool is_volatile_v = false;
+inline constexpr bool is_volatile_v = false;
 
 template <typename T>
-constexpr bool is_volatile_v<volatile T> = true;
+inline constexpr bool is_volatile_v<volatile T> = true;
 
 /**
  * Derives from `true_type` iff `T` is an volatile-qualified type.
@@ -393,7 +393,8 @@ struct is_volatile : bool_constant<is_volatile_v<T>> {};
  * `true` iff `T` is a function type.
  */
 template <typename T>
-constexpr bool is_function_v = !is_reference_v<T> && !is_const_v<const T>;
+inline constexpr bool is_function_v =
+    !is_reference_v<T> && !is_const_v<const T>;
 
 /**
  * Derives from `true_type` iff `T` is a function type.
@@ -409,10 +410,10 @@ template <typename To>
 void try_convert(To);
 
 template <typename From, typename To, typename = void>
-constexpr bool is_convertible_test_v = false;
+inline constexpr bool is_convertible_test_v = false;
 
 template <typename From, typename To>
-constexpr bool is_convertible_test_v<
+inline constexpr bool is_convertible_test_v<
     From, To, decltype(::psl::impl::try_convert<To>(declval<From>()))> = true;
 
 } // namespace impl
@@ -423,10 +424,10 @@ constexpr bool is_convertible_test_v<
  */
 template <typename From, typename To,
           bool = is_void_v<From> || is_array_v<To> || is_function_v<To>>
-constexpr bool is_convertible_v = is_void_v<To>;
+inline constexpr bool is_convertible_v = is_void_v<To>;
 
 template <typename From, typename To>
-constexpr bool is_convertible_v<From, To, false> =
+inline constexpr bool is_convertible_v<From, To, false> =
     impl::is_convertible_test_v<From, To>;
 
 /**
@@ -487,17 +488,17 @@ struct is_integral : impl::is_integral<remove_cv_t<T>> {};
  * type.
  */
 template <typename T>
-constexpr bool is_integral_v = is_integral<T>::value;
+inline constexpr bool is_integral_v = is_integral<T>::value;
 
 
 /**
  * `true` iff `T` is a signed integer type.
  */
 template <typename T, bool = is_integral_v<T>>
-constexpr bool is_signed_v = T(-1) < T(0);
+inline constexpr bool is_signed_v = T(-1) < T(0);
 
 template <typename T>
-constexpr bool is_signed_v<T, false> = false;
+inline constexpr bool is_signed_v<T, false> = false;
 
 /**
  * Derives from `true_type` iff `T` is a signed integer type. Otherwise, derives
@@ -511,10 +512,10 @@ struct is_signed : bool_constant<is_signed_v<T>> {};
  * `true` iff `T` is an unsigned integer type.
  */
 template <typename T, bool = is_integral_v<T>>
-constexpr bool is_unsigned_v = T(-1) > T(0);
+inline constexpr bool is_unsigned_v = T(-1) > T(0);
 
 template <typename T>
-constexpr bool is_unsigned_v<T, false> = false;
+inline constexpr bool is_unsigned_v<T, false> = false;
 
 /**
  * Derives from `true_type` iff `T` is an unsigned integer type.
@@ -526,7 +527,7 @@ struct is_unsigned : bool_constant<is_unsigned_v<T>> {};
 namespace impl {
 
 template <typename T>
-constexpr bool is_nonbool_integral_v =
+inline constexpr bool is_nonbool_integral_v =
     is_integral_v<T> && !is_same_v<remove_cv_t<T>, bool>;
 
 


### PR DESCRIPTION
When available, the clang-tidy linter is now run during build on every file before compilation. Editor support (including inline quick fixes for many of the trivially actionable warnings) is available through `clangd` by passing `--clang-tidy` to the server.

The linter is currently configured to detect readability hazards (missing braces on control statements, unnamed parameters, etc.), enforce naming conventions (`snake_case` for everything except `TemplateParameters`), suggest modernization opportunities (`nullptr`, `override`, `[[nodiscard]]`, etc.), and flag suspicious or bug-prone code. For details, see the [full list of checks](http://releases.llvm.org/9.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/list.html), particularly the `readability-`, `modernize-use-` and `bugprone-` sections.

Currently, the 'magic number' check (flagging numbers that should probably be named constants) had to be disabled because it was too noisy - we may want to reconsider in the future. Checks can also be disabled on a line-by-line basis by using appropriately-placed `// NOLINT` or `// NOLINTNEXTLINE` comments.